### PR TITLE
XBox 360 Guitar Hero changes

### DIFF
--- a/README
+++ b/README
@@ -27,6 +27,7 @@ rbdrum2midi
 Tested Drumkits:
 -PS3 Rockband pro drumkit
 -PS3 Guitar Hero world tour kit
+-XBox 360 Guitar Hero world tour kit
 -PS3 Rockband 1 drumkit
 -XBox 360 Rockband 1 drumkit
 If your kit isn't listed theres a chance it will still work. If it is a rockband kit try the option '-rb1'.If it doesn't we will happily add support for your kit if you can build and run the commands:

--- a/src/ghkit.c
+++ b/src/ghkit.c
@@ -5,6 +5,24 @@
 
 void init_gh_kit(MIDIDRUM* MIDI_DRUM)
 {
+
+    switch(MIDI_DRUM->kit)
+    {
+     case XB_GUITAR_HERO:
+	    MIDI_DRUM->buf_indx[RED] = 13;
+	    MIDI_DRUM->buf_mask[RED] = 0xFF;	
+	    MIDI_DRUM->buf_indx[YELLOW_CYMBAL] = 14;
+	    MIDI_DRUM->buf_mask[YELLOW_CYMBAL] = 0xff;
+	    MIDI_DRUM->buf_indx[BLUE] = 15;
+	    MIDI_DRUM->buf_mask[BLUE] = 0xff;
+	    MIDI_DRUM->buf_indx[GREEN] = 12;
+	    MIDI_DRUM->buf_mask[GREEN] = 0xff;
+	    MIDI_DRUM->buf_indx[ORANGE_CYMBAL] = 16;
+	    MIDI_DRUM->buf_mask[ORANGE_CYMBAL] = 0xff;
+	    MIDI_DRUM->buf_indx[ORANGE_BASS] = 17;
+	    MIDI_DRUM->buf_mask[ORANGE_BASS] = 0xff;
+        break;          
+     case PS_GUITAR_HERO:     
 	    MIDI_DRUM->buf_indx[RED] = 12;
 	    MIDI_DRUM->buf_mask[RED] = 0xFF;	
 	    MIDI_DRUM->buf_indx[YELLOW_CYMBAL] = 11;
@@ -17,6 +35,9 @@ void init_gh_kit(MIDIDRUM* MIDI_DRUM)
 	    MIDI_DRUM->buf_mask[ORANGE_CYMBAL] = 0xff;
 	    MIDI_DRUM->buf_indx[ORANGE_BASS] = 15;
 	    MIDI_DRUM->buf_mask[ORANGE_BASS] = 0xff;
+        break;
+    }
+	    
 }
 
 static inline void calc_velocity(MIDIDRUM* MIDI_DRUM, unsigned char value)

--- a/src/main.c
+++ b/src/main.c
@@ -89,12 +89,20 @@ static int find_rbdrum_device(MIDIDRUM* MIDI_DRUM, struct libusb_device_handle *
     //PS3 GH kit
     *devh = libusb_open_device_with_vid_pid(NULL, 0x12ba, 0x0120);
     if(*devh){
-        MIDI_DRUM->kit=GUITAR_HERO;
+        MIDI_DRUM->kit=PS_GUITAR_HERO;
         if(MIDI_DRUM->verbose)printf("PS3 Guitar Hero kit found\n");
         if(claim_interface(devh) == 0)
             return 0;
     }
 
+    //xbox360 GH kit
+    *devh = libusb_open_device_with_vid_pid(NULL, 0x045e, 0x0291);
+    if(*devh){
+        MIDI_DRUM->kit=XB_GUITAR_HERO;
+        if(MIDI_DRUM->verbose)printf("XBox Guitar Hero kit found\n");
+        if(claim_interface(devh) == 0)
+            return 0;
+    }
 
     //GUITARS
     //ps3
@@ -144,7 +152,8 @@ void init_kit(MIDIDRUM* MIDI_DRUM)
         case XB_ROCKBAND1:
             init_rb1_kit(MIDI_DRUM);
             break;
-        case GUITAR_HERO:
+        case XB_GUITAR_HERO:
+        case PS_GUITAR_HERO:        
             init_gh_kit(MIDI_DRUM);
             break;
         case XB_RB_GUITAR:
@@ -357,7 +366,7 @@ static int alloc_transfers(MIDIDRUM* MIDI_DRUM, libusb_device_handle *devh, stru
             sizeof(MIDI_DRUM->irqbuf), cb_irq_rb1, (void*)MIDI_DRUM, 0);
         if( MIDI_DRUM->verbose)printf("Rock Band 1 drum kit connected.\n");
     }
-    else if(MIDI_DRUM->kit == GUITAR_HERO){
+    else if(MIDI_DRUM->kit == PS_GUITAR_HERO || MIDI_DRUM->kit == XB_GUITAR_HERO){
         libusb_fill_interrupt_transfer(*irq_transfer, devh, EP_INTR, MIDI_DRUM->irqbuf,
             sizeof(MIDI_DRUM->irqbuf), cb_irq_gh, (void*)MIDI_DRUM, 0);
         if( MIDI_DRUM->verbose)printf("Guitar Hero World Tour drum kit connected.\n");
@@ -388,7 +397,7 @@ int init_jack(MIDIDRUM* MIDI_DRUM, JACK_SEQ* seq, unsigned char verbose)
     else if(MIDI_DRUM->kit == PS_ROCKBAND1 || MIDI_DRUM->kit == XB_ROCKBAND1){
         return init_jack_client(seq,verbose,"Rockband 1 Drum Controller");
     }
-    else if(MIDI_DRUM->kit == GUITAR_HERO){
+    else if(MIDI_DRUM->kit == PS_GUITAR_HERO || MIDI_DRUM->kit == XB_GUITAR_HERO){
         return init_jack_client(seq,verbose,"Guitar Hero Drum Controller");
     }
     else if(MIDI_DRUM->kit == PS_RB_GUITAR || MIDI_DRUM->kit == XB_RB_GUITAR){

--- a/src/mididrum.h
+++ b/src/mididrum.h
@@ -12,7 +12,7 @@
 #include <libusb-1.0/libusb.h>
 
 #define EP_INTR			(1 | LIBUSB_ENDPOINT_IN)
-#define INTR_LENGTH		27
+#define INTR_LENGTH		47
 
 #define DEFAULT_CHANNEL 9
 
@@ -111,7 +111,8 @@ typedef enum {
     WII_ROCKBAND,
     XB_ROCKBAND1,
     PS_ROCKBAND1,
-    GUITAR_HERO,
+    XB_GUITAR_HERO,
+    PS_GUITAR_HERO,    
     DRUMS,
 
     XB_RB_GUITAR,


### PR DESCRIPTION
Changes for Xbox Guitar Hero support.

I just split the GUITAR_HERO define into PS_GUITAR_HERO and XB_GUITAR_HERO because the PS3 and Xbox versions use the same code with the difference being that the pads are rearranged, so there is no real need to add extra files to support the XBox Guitar Hero.

INTR_LENGTH	needed to be increased from 27 o 47 otherwise their where memory errors.