### PR TITLE
Xbox360 rockband 3 keyboard support

### DIFF
--- a/README
+++ b/README
@@ -1,7 +1,7 @@
 Rockband Instrument Midi Driver
 by Randommatt and ssj71
 
-Version 0.6
+Version 0.7
 
 Installation:
 Requires libusb-1.0, libjack, and libasound2 dev packages to compile and runtime libraries to run
@@ -38,6 +38,7 @@ Hit each drum a few times and copy and paste the output to a new issue in github
 Other Tested Instruments:
 -PS3 Rockband wireless guitar
 -Xbox 360 Rockband wired guitar
+-Xbox 360 Rockband3 wireless keyboard (-xbkey argument)
 
 Usage:
 connect rbdrumkit wireless dongle (PS3 works, Wii should, xbox probably won't), 

--- a/src/main.c
+++ b/src/main.c
@@ -96,13 +96,13 @@ static int find_rbdrum_device(MIDIDRUM* MIDI_DRUM, struct libusb_device_handle *
     }
 
     //xbox360 GH kit
-    *devh = libusb_open_device_with_vid_pid(NULL, 0x045e, 0x0291);
+/*    *devh = libusb_open_device_with_vid_pid(NULL, 0x045e, 0x0291);
     if(*devh){
         MIDI_DRUM->kit=XB_GUITAR_HERO;
         if(MIDI_DRUM->verbose)printf("XBox Guitar Hero kit found\n");
         if(claim_interface(devh) == 0)
             return 0;
-    }
+    }*/
 
     //GUITARS
     //ps3
@@ -129,6 +129,15 @@ static int find_rbdrum_device(MIDIDRUM* MIDI_DRUM, struct libusb_device_handle *
     if(*devh){
         MIDI_DRUM->kit=WII_RB3_KEYBOARD;
         if(MIDI_DRUM->verbose)printf("Wii keyboard found\n");
+        if(claim_interface(devh) == 0)
+            return 0;
+    }
+
+    //Xbox360
+    *devh = libusb_open_device_with_vid_pid(NULL, 0x045e, 0x0291);
+    if(*devh){
+        MIDI_DRUM->kit=WII_RB3_KEYBOARD;
+        if(MIDI_DRUM->verbose)printf("Xbox360 keyboard found\n");
         if(claim_interface(devh) == 0)
             return 0;
     }

--- a/src/main.c
+++ b/src/main.c
@@ -95,14 +95,14 @@ static int find_rbdrum_device(MIDIDRUM* MIDI_DRUM, struct libusb_device_handle *
             return 0;
     }
 
-    //xbox360 GH kit
-/*    *devh = libusb_open_device_with_vid_pid(NULL, 0x045e, 0x0291);
+    //xbox360 GH kit/keytar
+    *devh = libusb_open_device_with_vid_pid(NULL, 0x045e, 0x0291);
     if(*devh){
         MIDI_DRUM->kit=XB_GUITAR_HERO;
-        if(MIDI_DRUM->verbose)printf("XBox Guitar Hero kit found\n");
+        if(MIDI_DRUM->verbose)printf("XBox Guitar Hero kit or keyboard found\n");
         if(claim_interface(devh) == 0)
             return 0;
-    }*/
+    }
 
     //GUITARS
     //ps3
@@ -133,15 +133,6 @@ static int find_rbdrum_device(MIDIDRUM* MIDI_DRUM, struct libusb_device_handle *
             return 0;
     }
 
-    //Xbox360
-    *devh = libusb_open_device_with_vid_pid(NULL, 0x045e, 0x0291);
-    if(*devh){
-        MIDI_DRUM->kit=WII_RB3_KEYBOARD;
-        if(MIDI_DRUM->verbose)printf("Xbox360 keyboard found\n");
-        if(claim_interface(devh) == 0)
-            return 0;
-    }
-  
     return *devh ? 0 : -EIO;
 }
 
@@ -170,6 +161,7 @@ void init_kit(MIDIDRUM* MIDI_DRUM)
             init_rb_guitar(MIDI_DRUM);
             break;
         case WII_RB3_KEYBOARD:
+		  case XB_RB3_KEYBOARD:
             init_rb3_keyboard(MIDI_DRUM);
             break;
     }
@@ -364,6 +356,11 @@ static int alloc_transfers(MIDIDRUM* MIDI_DRUM, libusb_device_handle *devh, stru
             sizeof(MIDI_DRUM->irqbuf), cb_irq_dbg, (void*)MIDI_DRUM, 0);
         if( MIDI_DRUM->verbose)printf("Debug Mode Enabled..\n");
     }
+    else if(MIDI_DRUM->kit == XB_RB3_KEYBOARD){
+        libusb_fill_interrupt_transfer(*irq_transfer, devh, EP_INTR, MIDI_DRUM->irqbuf,
+            sizeof(MIDI_DRUM->irqbuf), cb_irq_rb3_keyboard, (void*)MIDI_DRUM, 0);
+        if( MIDI_DRUM->verbose)printf("Xbox Rock Band 3 Wireless keyboard detected.\n");
+    }
     else if(MIDI_DRUM->kit == PS_ROCKBAND  || MIDI_DRUM->kit == XB_ROCKBAND ||
             MIDI_DRUM->kit == WII_ROCKBAND){
         libusb_fill_interrupt_transfer(*irq_transfer, devh, EP_INTR, MIDI_DRUM->irqbuf,
@@ -412,7 +409,7 @@ int init_jack(MIDIDRUM* MIDI_DRUM, JACK_SEQ* seq, unsigned char verbose)
     else if(MIDI_DRUM->kit == PS_RB_GUITAR || MIDI_DRUM->kit == XB_RB_GUITAR){
         return init_jack_client(seq,verbose,"Rockband Guitar Controller");
     }
-    else if(MIDI_DRUM->kit == WII_RB3_KEYBOARD){
+    else if(MIDI_DRUM->kit == WII_RB3_KEYBOARD || MIDI_DRUM->kit == XB_RB3_KEYBOARD){
         return init_jack_client(seq,verbose,"Rockband Keyboard Controller");
     }
 
@@ -451,6 +448,7 @@ void useage()
     printf("    -ocy/ycy/bcy/gcy <value>    set midi note for -color of cymbal\n");
     printf("    -ob/bkb <value>             set midi note for -color bass pedal\n");
     printf("    -rb1                        specify rockband 1 drumset\n");
+    printf("    -xbkey                      specify rockband 3 xbox keytar\n");
     printf("    -htdm <value>               set hihat color i.e, r/y.../bcy/gcy\n");
     printf("    -htp <value>                set hihat pedal color i.e. ob/bkb*\n"); 
     printf("    -hto <value>                set open hihat midi value of hihat mode drum\n");
@@ -547,6 +545,10 @@ int main(int argc, char **argv)
             else if (strcmp(argv[i], "-rb1") == 0) {
                 //rockband 1 set, use different irq routine
                 MIDI_DRUM->kit = PS_ROCKBAND1;
+            }
+            else if (strcmp(argv[i], "-xbkey") == 0) {
+                //rockband 3 keytar for xbox
+                MIDI_DRUM->kit = XB_RB3_KEYBOARD;
             }
             else if (strcmp(argv[i], "-ocy") == 0) {
                 //orange cymbal
@@ -709,6 +711,11 @@ int main(int argc, char **argv)
             break;
         }
     }
+	 //reassign xb rb3 keyboard if option selected
+	 else if (MIDI_DRUM->kit==XB_RB3_KEYBOARD){
+		  r = find_rbdrum_device(MIDI_DRUM,&devh);
+ 		  MIDI_DRUM->kit = XB_RB3_KEYBOARD;
+	 }
     else
         r = find_rbdrum_device(MIDI_DRUM,&devh);
     if (r < 0) {

--- a/src/mididrum.h
+++ b/src/mididrum.h
@@ -119,7 +119,8 @@ typedef enum {
     PS_RB_GUITAR,
     GUITARS,
 
-    WII_RB3_KEYBOARD
+    WII_RB3_KEYBOARD,
+    XB_RB3_KEYBOARD
 }kit_types;
 
 //primary object for the system

--- a/src/rb3keyboard.c
+++ b/src/rb3keyboard.c
@@ -58,15 +58,15 @@ void init_rb3_keyboard(MIDIDRUM *MIDI_DRUM) {
     MIDI_DRUM->buf_indx[RIGHT] = 7;
     MIDI_DRUM->buf_mask[RIGHT] = 0x08;
 
-    MIDI_DRUM->buf_indx[MINUS] = 8;
-    MIDI_DRUM->buf_mask[MINUS] = 0x04;
-    MIDI_DRUM->buf_indx[PLUS] = 8;
-    MIDI_DRUM->buf_mask[PLUS] = 0x08;
+    MIDI_DRUM->buf_indx[MINUS] = 7;
+    MIDI_DRUM->buf_mask[MINUS] = 0x40;
+    MIDI_DRUM->buf_indx[PLUS] = 7;
+    MIDI_DRUM->buf_mask[PLUS] = 0x80;
 
-    MIDI_DRUM->buf_indx[A_BUTTON] = 8;
-    MIDI_DRUM->buf_mask[A_BUTTON] = 0x01;
-    MIDI_DRUM->buf_indx[B_BUTTON] = 8;
-    MIDI_DRUM->buf_mask[B_BUTTON] = 0x02;
+    MIDI_DRUM->buf_indx[A_BUTTON] = 7;
+    MIDI_DRUM->buf_mask[A_BUTTON] = 0x10;
+    MIDI_DRUM->buf_indx[B_BUTTON] = 7;
+    MIDI_DRUM->buf_mask[B_BUTTON] = 0x20;
     MIDI_DRUM->buf_indx[ONE] = 0;
     MIDI_DRUM->buf_mask[ONE] = 0x01;
     MIDI_DRUM->buf_indx[TWO] = 0;
@@ -187,13 +187,13 @@ void cb_irq_rb3_keyboard(struct libusb_transfer *transfer) {
   // platforms, when using the midi out port the 1 and B buttons change octave
   // for now, I don't mind just doing it this way
   if (MIDI_DRUM->drum_state[MINUS] && !MIDI_DRUM->prev_state[MINUS] &&
-      MIDI_DRUM->octave > -4)
-    MIDI_DRUM->octave--;
+      MIDI_DRUM->octave > -4) {
+    MIDI_DRUM->octave--; }
   if (MIDI_DRUM->drum_state[PLUS] && !MIDI_DRUM->prev_state[PLUS] &&
-      MIDI_DRUM->octave < 4)
-    MIDI_DRUM->octave++;
-  if (MIDI_DRUM->drum_state[CONNECT] && !MIDI_DRUM->prev_state[CONNECT])
-    MIDI_DRUM->octave = 0;
+      MIDI_DRUM->octave < 4) {
+    MIDI_DRUM->octave++; }
+  if (MIDI_DRUM->drum_state[CONNECT] && !MIDI_DRUM->prev_state[CONNECT]) {
+    MIDI_DRUM->octave = 0; }
 
   // now the pitchbender
   get_state(MIDI_DRUM, EXPR_TOGGLE);

--- a/src/rb3keyboard.c
+++ b/src/rb3keyboard.c
@@ -5,217 +5,218 @@
 //#include "constants.h"
 
 void init_rb3_keyboard(MIDIDRUM *MIDI_DRUM) {
-  switch (MIDI_DRUM->kit) {
-  case WII_RB3_KEYBOARD:
-    MIDI_DRUM->buf_indx[ONE] = 0;
-    MIDI_DRUM->buf_mask[ONE] = 0x04;
-    MIDI_DRUM->buf_indx[B_BUTTON] = 0;
-    MIDI_DRUM->buf_mask[B_BUTTON] = 0x04;
+    switch (MIDI_DRUM->kit) {
+    case WII_RB3_KEYBOARD:
+        MIDI_DRUM->buf_indx[ONE] = 0;
+        MIDI_DRUM->buf_mask[ONE] = 0x04;
+        MIDI_DRUM->buf_indx[B_BUTTON] = 0;
+        MIDI_DRUM->buf_mask[B_BUTTON] = 0x04;
 
-    MIDI_DRUM->buf_indx[UP] = 2;
-    MIDI_DRUM->buf_mask[UP] = 0x08;
-    MIDI_DRUM->buf_indx[DOWN] = 2;
-    MIDI_DRUM->buf_mask[DOWN] = 0x04;
-    MIDI_DRUM->buf_indx[LEFT] = 2;
-    MIDI_DRUM->buf_mask[LEFT] = 0x01;
-    MIDI_DRUM->buf_indx[RIGHT] = 2;
-    MIDI_DRUM->buf_mask[RIGHT] = 0x02;
+        MIDI_DRUM->buf_indx[UP] = 2;
+        MIDI_DRUM->buf_mask[UP] = 0x08;
+        MIDI_DRUM->buf_indx[DOWN] = 2;
+        MIDI_DRUM->buf_mask[DOWN] = 0x04;
+        MIDI_DRUM->buf_indx[LEFT] = 2;
+        MIDI_DRUM->buf_mask[LEFT] = 0x01;
+        MIDI_DRUM->buf_indx[RIGHT] = 2;
+        MIDI_DRUM->buf_mask[RIGHT] = 0x02;
 
-    MIDI_DRUM->buf_indx[MINUS] = 1;
-    MIDI_DRUM->buf_mask[MINUS] = 0x01;
-    MIDI_DRUM->buf_indx[PLUS] = 1;
-    MIDI_DRUM->buf_mask[PLUS] = 0x02;
+        MIDI_DRUM->buf_indx[MINUS] = 1;
+        MIDI_DRUM->buf_mask[MINUS] = 0x01;
+        MIDI_DRUM->buf_indx[PLUS] = 1;
+        MIDI_DRUM->buf_mask[PLUS] = 0x02;
 
-    MIDI_DRUM->buf_indx[A_BUTTON] = 0;
-    MIDI_DRUM->buf_mask[A_BUTTON] = 0x02;
-    MIDI_DRUM->buf_indx[B_BUTTON] = 0;
-    MIDI_DRUM->buf_mask[B_BUTTON] = 0x04;
-    MIDI_DRUM->buf_indx[ONE] = 0;
-    MIDI_DRUM->buf_mask[ONE] = 0x01;
-    MIDI_DRUM->buf_indx[TWO] = 0;
-    MIDI_DRUM->buf_mask[TWO] = 0x08;
+        MIDI_DRUM->buf_indx[A_BUTTON] = 0;
+        MIDI_DRUM->buf_mask[A_BUTTON] = 0x02;
+        MIDI_DRUM->buf_indx[B_BUTTON] = 0;
+        MIDI_DRUM->buf_mask[B_BUTTON] = 0x04;
+        MIDI_DRUM->buf_indx[ONE] = 0;
+        MIDI_DRUM->buf_mask[ONE] = 0x01;
+        MIDI_DRUM->buf_indx[TWO] = 0;
+        MIDI_DRUM->buf_mask[TWO] = 0x08;
 
-    MIDI_DRUM->buf_indx[CONNECT] = 1;
-    MIDI_DRUM->buf_mask[CONNECT] = 0x10;
+        MIDI_DRUM->buf_indx[CONNECT] = 1;
+        MIDI_DRUM->buf_mask[CONNECT] = 0x10;
 
-    MIDI_DRUM->buf_indx[KEYS0] = 5;
-    MIDI_DRUM->buf_indx[KEYS1] = 6;
-    MIDI_DRUM->buf_indx[KEYS2] = 7;
-    MIDI_DRUM->buf_indx[KEYS3] = 8;
+        MIDI_DRUM->buf_indx[KEYS0] = 5;
+        MIDI_DRUM->buf_indx[KEYS1] = 6;
+        MIDI_DRUM->buf_indx[KEYS2] = 7;
+        MIDI_DRUM->buf_indx[KEYS3] = 8;
 
-    MIDI_DRUM->buf_indx[EXPRESSION] = 15;
-    MIDI_DRUM->buf_mask[EXPRESSION] = 0x7f;
-    MIDI_DRUM->buf_indx[EXPR_TOGGLE] = 13;
-    MIDI_DRUM->buf_mask[EXPR_TOGGLE] = 0x80;
-    break;
-  case XB_RB3_KEYBOARD:
-    MIDI_DRUM->buf_indx[UP] = 7;
-    MIDI_DRUM->buf_mask[UP] = 0x01;
-    MIDI_DRUM->buf_indx[DOWN] = 7;
-    MIDI_DRUM->buf_mask[DOWN] = 0x02;
-    MIDI_DRUM->buf_indx[LEFT] = 7;
-    MIDI_DRUM->buf_mask[LEFT] = 0x04;
-    MIDI_DRUM->buf_indx[RIGHT] = 7;
-    MIDI_DRUM->buf_mask[RIGHT] = 0x08;
+        MIDI_DRUM->buf_indx[EXPRESSION] = 15;
+        MIDI_DRUM->buf_mask[EXPRESSION] = 0x7f;
+        MIDI_DRUM->buf_indx[EXPR_TOGGLE] = 13;
+        MIDI_DRUM->buf_mask[EXPR_TOGGLE] = 0x80;
+        break;
+    case XB_RB3_KEYBOARD:
+        MIDI_DRUM->buf_indx[UP] = 7;
+        MIDI_DRUM->buf_mask[UP] = 0x01;
+        MIDI_DRUM->buf_indx[DOWN] = 7;
+        MIDI_DRUM->buf_mask[DOWN] = 0x02;
+        MIDI_DRUM->buf_indx[LEFT] = 7;
+        MIDI_DRUM->buf_mask[LEFT] = 0x04;
+        MIDI_DRUM->buf_indx[RIGHT] = 7;
+        MIDI_DRUM->buf_mask[RIGHT] = 0x08;
 
-    MIDI_DRUM->buf_indx[MINUS] = 7;
-    MIDI_DRUM->buf_mask[MINUS] = 0x40;
-    MIDI_DRUM->buf_indx[PLUS] = 7;
-    MIDI_DRUM->buf_mask[PLUS] = 0x80;
+        MIDI_DRUM->buf_indx[MINUS] = 7;
+        MIDI_DRUM->buf_mask[MINUS] = 0x40;
+        MIDI_DRUM->buf_indx[PLUS] = 7;
+        MIDI_DRUM->buf_mask[PLUS] = 0x80;
 
-    MIDI_DRUM->buf_indx[A_BUTTON] = 7;
-    MIDI_DRUM->buf_mask[A_BUTTON] = 0x10;
-    MIDI_DRUM->buf_indx[B_BUTTON] = 7;
-    MIDI_DRUM->buf_mask[B_BUTTON] = 0x20;
-    MIDI_DRUM->buf_indx[ONE] = 0;
-    MIDI_DRUM->buf_mask[ONE] = 0x01;
-    MIDI_DRUM->buf_indx[TWO] = 0;
-    MIDI_DRUM->buf_mask[TWO] = 0x08;
+        MIDI_DRUM->buf_indx[A_BUTTON] = 7;
+        MIDI_DRUM->buf_mask[A_BUTTON] = 0x10;
+        MIDI_DRUM->buf_indx[B_BUTTON] = 7;
+        MIDI_DRUM->buf_mask[B_BUTTON] = 0x20;
+        MIDI_DRUM->buf_indx[ONE] = 0;
+        MIDI_DRUM->buf_mask[ONE] = 0x01;
+        MIDI_DRUM->buf_indx[TWO] = 0;
+        MIDI_DRUM->buf_mask[TWO] = 0x08;
 
-    MIDI_DRUM->buf_indx[CONNECT] = 1;
-    MIDI_DRUM->buf_mask[CONNECT] = 0x10;
+        MIDI_DRUM->buf_indx[CONNECT] = 1;
+        MIDI_DRUM->buf_mask[CONNECT] = 0x10;
 
-    MIDI_DRUM->buf_indx[KEYS0] = 8;
-    MIDI_DRUM->buf_indx[KEYS1] = 9;
-    MIDI_DRUM->buf_indx[KEYS2] = 10;
-    MIDI_DRUM->buf_indx[KEYS3] = 11;
+        MIDI_DRUM->buf_indx[KEYS0] = 8;
+        MIDI_DRUM->buf_indx[KEYS1] = 9;
+        MIDI_DRUM->buf_indx[KEYS2] = 10;
+        MIDI_DRUM->buf_indx[KEYS3] = 11;
 
-    MIDI_DRUM->buf_indx[EXPRESSION] = 15;
-    MIDI_DRUM->buf_mask[EXPRESSION] = 0x7f;
-    MIDI_DRUM->buf_indx[EXPR_TOGGLE] = 13;
-    MIDI_DRUM->buf_mask[EXPR_TOGGLE] = 0x80;
+        MIDI_DRUM->buf_indx[EXPRESSION] = 15;
+        MIDI_DRUM->buf_mask[EXPRESSION] = 0x7f;
+        MIDI_DRUM->buf_indx[EXPR_TOGGLE] = 13;
+        MIDI_DRUM->buf_mask[EXPR_TOGGLE] = 0x80;
 
-    MIDI_DRUM->buf_indx[NOTHING] = 17;
-    MIDI_DRUM->buf_mask[NOTHING] = 0x7f;
-    break;
-  }
-  MIDI_DRUM->key_state = 0;
-  MIDI_DRUM->prev_keystate = 0;
-  MIDI_DRUM->velocity = 0;
-  MIDI_DRUM->channel = 0;
+        MIDI_DRUM->buf_indx[NOTHING] = 17;
+        MIDI_DRUM->buf_mask[NOTHING] = 0x7f;
+        break;
+    }
+    MIDI_DRUM->key_state = 0;
+    MIDI_DRUM->prev_keystate = 0;
+    MIDI_DRUM->velocity = 0;
+    MIDI_DRUM->channel = 0;
 }
 
 static inline void get_velocity(MIDIDRUM *MIDI_DRUM) {
-  // Velocity data is transmitted for up to 5 keys pressed same time.
-  // This is the reason for the weird velocity reading algorithm.
-  // For this reason the 6th key wont get any reasonable velocity data.
-  if (MIDI_DRUM->buf[12] != 0)
-    MIDI_DRUM->velocity = MIDI_DRUM->buf[12];
-  else if (MIDI_DRUM->buf[11] != 0)
-    MIDI_DRUM->velocity = MIDI_DRUM->buf[11];
-  else if (MIDI_DRUM->buf[10] != 0)
-    MIDI_DRUM->velocity = MIDI_DRUM->buf[10];
-  else if (MIDI_DRUM->buf[9] != 0)
-    MIDI_DRUM->velocity = MIDI_DRUM->buf[9];
-  else
-    MIDI_DRUM->velocity = MIDI_DRUM->buf[8] & 0x7f;
+    // Velocity data is transmitted for up to 5 keys pressed same time.
+    // This is the reason for the weird velocity reading algorithm.
+    // For this reason the 6th key wont get any reasonable velocity data.
+    if (MIDI_DRUM->buf[12] != 0)
+        MIDI_DRUM->velocity = MIDI_DRUM->buf[12];
+    else if (MIDI_DRUM->buf[11] != 0)
+        MIDI_DRUM->velocity = MIDI_DRUM->buf[11];
+    else if (MIDI_DRUM->buf[10] != 0)
+        MIDI_DRUM->velocity = MIDI_DRUM->buf[10];
+    else if (MIDI_DRUM->buf[9] != 0)
+        MIDI_DRUM->velocity = MIDI_DRUM->buf[9];
+    else
+        MIDI_DRUM->velocity = MIDI_DRUM->buf[8] & 0x7f;
 }
 
 static inline void handle_key(MIDIDRUM *MIDI_DRUM, unsigned char key) {
-  // printf("%d\n",1<<(24-key));
-  if ((MIDI_DRUM->key_state & (1 << (24 - key))) !=
-      (MIDI_DRUM->prev_keystate & (1 << (24 - key)))) {
-    get_velocity(MIDI_DRUM);
-    printf("key %d\n", key);
-    if (MIDI_DRUM->key_state & (1 << (24 - key))) {
-      MIDI_DRUM->notedown(MIDI_DRUM->sequencer, MIDI_DRUM->channel,
-                          48 + key + 12 * MIDI_DRUM->octave,
-                          MIDI_DRUM->velocity);
+    // printf("%d\n",1<<(24-key));
+    if ((MIDI_DRUM->key_state & (1 << (24 - key))) !=
+            (MIDI_DRUM->prev_keystate & (1 << (24 - key)))) {
+        get_velocity(MIDI_DRUM);
+        printf("key %d\n", key);
+        if (MIDI_DRUM->key_state & (1 << (24 - key))) {
+            MIDI_DRUM->notedown(MIDI_DRUM->sequencer, MIDI_DRUM->channel,
+                                                    48 + key + 12 * MIDI_DRUM->octave,
+                                                    MIDI_DRUM->velocity);
+        }
     }
-  }
-  if (!(MIDI_DRUM->key_state & (1 << (24 - key)))) {
-    MIDI_DRUM->noteup(MIDI_DRUM->sequencer, MIDI_DRUM->channel,
-                      48 + key + 12 * MIDI_DRUM->octave, 0);
-  }
+    if (!(MIDI_DRUM->key_state & (1 << (24 - key)))) {
+        MIDI_DRUM->noteup(MIDI_DRUM->sequencer, MIDI_DRUM->channel,
+                                            48 + key + 12 * MIDI_DRUM->octave, 0);
+    }
 }
 
 // callback for rockband3 keyboard
 void cb_irq_rb3_keyboard(struct libusb_transfer *transfer) {
-  MIDIDRUM *MIDI_DRUM = (MIDIDRUM *)transfer->user_data;
-  if (transfer->status != LIBUSB_TRANSFER_COMPLETED) {
-    fprintf(stderr, "irq transfer status %d? %d\n", transfer->status,
-            LIBUSB_TRANSFER_ERROR);
-    do_exit = 2;
-    libusb_free_transfer(transfer);
-    transfer = NULL;
-    return;
-  }
-
-  // the keys are the most critical for latency, ctl values can be slower
-  MIDI_DRUM->key_state = (MIDI_DRUM->buf[MIDI_DRUM->buf_indx[KEYS0]] << 17) +
-                         (MIDI_DRUM->buf[MIDI_DRUM->buf_indx[KEYS1]] << 9) +
-                         (MIDI_DRUM->buf[MIDI_DRUM->buf_indx[KEYS2]] << 1) +
-                         ((MIDI_DRUM->buf[MIDI_DRUM->buf_indx[KEYS3]]) >> 7);
-  get_state(MIDI_DRUM, NOTHING);
-  if (MIDI_DRUM->drum_state[NOTHING]) {
-    handle_key(MIDI_DRUM, 0);
-    handle_key(MIDI_DRUM, 1);
-    handle_key(MIDI_DRUM, 2);
-    handle_key(MIDI_DRUM, 3);
-    handle_key(MIDI_DRUM, 4);
-    handle_key(MIDI_DRUM, 5);
-    handle_key(MIDI_DRUM, 6);
-    handle_key(MIDI_DRUM, 7);
-    handle_key(MIDI_DRUM, 8);
-    handle_key(MIDI_DRUM, 9);
-    handle_key(MIDI_DRUM, 10);
-    handle_key(MIDI_DRUM, 11);
-    handle_key(MIDI_DRUM, 12);
-    handle_key(MIDI_DRUM, 13);
-    handle_key(MIDI_DRUM, 14);
-    handle_key(MIDI_DRUM, 15);
-    handle_key(MIDI_DRUM, 16);
-    handle_key(MIDI_DRUM, 17);
-    handle_key(MIDI_DRUM, 18);
-    handle_key(MIDI_DRUM, 19);
-    handle_key(MIDI_DRUM, 20);
-    handle_key(MIDI_DRUM, 21);
-    handle_key(MIDI_DRUM, 22);
-    handle_key(MIDI_DRUM, 23);
-    handle_key(MIDI_DRUM, 24);
-  }
-
-  // these buttons control octave
-  // octave can get up to +-4 octaves
-  get_state(MIDI_DRUM, PLUS);
-  get_state(MIDI_DRUM, MINUS);
-  get_state(MIDI_DRUM, CONNECT);
-
-  // TODO: this leaves opportunity for currently-on notes to be "orphaned"
-  // so that the note-off comes for a different octave
-  // NOTE: Also the + and - buttons correspond to start and select on other
-  // platforms, when using the midi out port the 1 and B buttons change octave
-  // for now, I don't mind just doing it this way
-  if (MIDI_DRUM->drum_state[MINUS] &&
-      MIDI_DRUM->octave > -4) {
-    MIDI_DRUM->octave--; }
-  if (MIDI_DRUM->drum_state[PLUS] &&
-      MIDI_DRUM->octave < 4) {
-    MIDI_DRUM->octave++; }
-  if (MIDI_DRUM->drum_state[CONNECT] && !MIDI_DRUM->prev_state[CONNECT]) {
-    MIDI_DRUM->octave = 0; }
-
-  // now the pitchbender
-  get_state(MIDI_DRUM, EXPR_TOGGLE);
-  get_state(MIDI_DRUM, EXPRESSION);
-  if (MIDI_DRUM->drum_state[EXPRESSION] != MIDI_DRUM->prev_state[EXPRESSION]) {
-    if (MIDI_DRUM->drum_state[EXPR_TOGGLE]) {
-      // should be MOD wheel change
-    } else {
-      // TODO: figure out how this data is formatted.
-      MIDI_DRUM->pitchbend(MIDI_DRUM->sequencer, MIDI_DRUM->channel,
-                           MIDI_DRUM->drum_state[EXPRESSION]);
+    MIDIDRUM *MIDI_DRUM = (MIDIDRUM *)transfer->user_data;
+    if (transfer->status != LIBUSB_TRANSFER_COMPLETED) {
+        fprintf(stderr, "irq transfer status %d? %d\n", transfer->status,
+                        LIBUSB_TRANSFER_ERROR);
+        do_exit = 2;
+        libusb_free_transfer(transfer);
+        transfer = NULL;
+        return;
     }
-  }
 
-  memcpy(MIDI_DRUM->prev_state, MIDI_DRUM->drum_state, NUM_DRUMS);
+    // the keys are the most critical for latency, ctl values can be slower
+    MIDI_DRUM->key_state = (MIDI_DRUM->buf[MIDI_DRUM->buf_indx[KEYS0]] << 17) +
+                           (MIDI_DRUM->buf[MIDI_DRUM->buf_indx[KEYS1]] << 9) +
+                           (MIDI_DRUM->buf[MIDI_DRUM->buf_indx[KEYS2]] << 1) +
+                           ((MIDI_DRUM->buf[MIDI_DRUM->buf_indx[KEYS3]]) >> 7);
+    get_state(MIDI_DRUM, NOTHING);
+    if (MIDI_DRUM->drum_state[NOTHING]) {
+        handle_key(MIDI_DRUM, 0);
+        handle_key(MIDI_DRUM, 1);
+        handle_key(MIDI_DRUM, 2);
+        handle_key(MIDI_DRUM, 3);
+        handle_key(MIDI_DRUM, 4);
+        handle_key(MIDI_DRUM, 5);
+        handle_key(MIDI_DRUM, 6);
+        handle_key(MIDI_DRUM, 7);
+        handle_key(MIDI_DRUM, 8);
+        handle_key(MIDI_DRUM, 9);
+        handle_key(MIDI_DRUM, 10);
+        handle_key(MIDI_DRUM, 11);
+        handle_key(MIDI_DRUM, 12);
+        handle_key(MIDI_DRUM, 13);
+        handle_key(MIDI_DRUM, 14);
+        handle_key(MIDI_DRUM, 15);
+        handle_key(MIDI_DRUM, 16);
+        handle_key(MIDI_DRUM, 17);
+        handle_key(MIDI_DRUM, 18);
+        handle_key(MIDI_DRUM, 19);
+        handle_key(MIDI_DRUM, 20);
+        handle_key(MIDI_DRUM, 21);
+        handle_key(MIDI_DRUM, 22);
+        handle_key(MIDI_DRUM, 23);
+        handle_key(MIDI_DRUM, 24);
+    }
 
-  if (MIDI_DRUM->verbose) {
-    print_keys(MIDI_DRUM);
-    print_buf(MIDI_DRUM);
-  }
-  MIDI_DRUM->prev_keystate = MIDI_DRUM->key_state;
+    // these buttons control octave
+    // octave can get up to +-4 octaves
+    get_state(MIDI_DRUM, PLUS);
+    get_state(MIDI_DRUM, MINUS);
+    get_state(MIDI_DRUM, CONNECT);
 
-  if (libusb_submit_transfer(transfer) < 0)
-    do_exit = 2;
+    // TODO: this leaves opportunity for currently-on notes to be "orphaned"
+    // so that the note-off comes for a different octave
+    // NOTE: Also the + and - buttons correspond to start and select on other
+    // platforms, when using the midi out port the 1 and B buttons change octave
+    // for now, I don't mind just doing it this way
+    if (MIDI_DRUM->drum_state[MINUS] && MIDI_DRUM->octave > -4) {
+        MIDI_DRUM->octave--;
+    }
+    if (MIDI_DRUM->drum_state[PLUS] && MIDI_DRUM->octave < 4) {
+        MIDI_DRUM->octave++;
+    }
+    if (MIDI_DRUM->drum_state[CONNECT] && !MIDI_DRUM->prev_state[CONNECT]) {
+        MIDI_DRUM->octave = 0;
+    }
+
+    // now the pitchbender
+    get_state(MIDI_DRUM, EXPR_TOGGLE);
+    get_state(MIDI_DRUM, EXPRESSION);
+    if (MIDI_DRUM->drum_state[EXPRESSION] != MIDI_DRUM->prev_state[EXPRESSION]) {
+        if (MIDI_DRUM->drum_state[EXPR_TOGGLE]) {
+            // should be MOD wheel change
+        } else {
+            // TODO: figure out how this data is formatted.
+            MIDI_DRUM->pitchbend(MIDI_DRUM->sequencer, MIDI_DRUM->channel,
+                                                     MIDI_DRUM->drum_state[EXPRESSION]);
+        }
+    }
+
+    memcpy(MIDI_DRUM->prev_state, MIDI_DRUM->drum_state, NUM_DRUMS);
+
+    if (MIDI_DRUM->verbose) {
+        print_keys(MIDI_DRUM);
+        print_buf(MIDI_DRUM);
+    }
+    MIDI_DRUM->prev_keystate = MIDI_DRUM->key_state;
+
+    if (libusb_submit_transfer(transfer) < 0)
+        do_exit = 2;
 }

--- a/src/rb3keyboard.c
+++ b/src/rb3keyboard.c
@@ -186,10 +186,10 @@ void cb_irq_rb3_keyboard(struct libusb_transfer *transfer) {
   // NOTE: Also the + and - buttons correspond to start and select on other
   // platforms, when using the midi out port the 1 and B buttons change octave
   // for now, I don't mind just doing it this way
-  if (MIDI_DRUM->drum_state[MINUS] && !MIDI_DRUM->prev_state[MINUS] &&
+  if (MIDI_DRUM->drum_state[MINUS] &&
       MIDI_DRUM->octave > -4) {
     MIDI_DRUM->octave--; }
-  if (MIDI_DRUM->drum_state[PLUS] && !MIDI_DRUM->prev_state[PLUS] &&
+  if (MIDI_DRUM->drum_state[PLUS] &&
       MIDI_DRUM->octave < 4) {
     MIDI_DRUM->octave++; }
   if (MIDI_DRUM->drum_state[CONNECT] && !MIDI_DRUM->prev_state[CONNECT]) {

--- a/src/rb3keyboard.c
+++ b/src/rb3keyboard.c
@@ -83,12 +83,12 @@ static inline void handle_key(MIDIDRUM* MIDI_DRUM, unsigned char key)
     (MIDI_DRUM->prev_keystate&(1<<(24-key))))
     {
         get_velocity(MIDI_DRUM);
-        //printf("key %d\n",key);
+        printf("key %d\n",key);
         if (MIDI_DRUM->key_state&(1<<(24-key))){
             MIDI_DRUM->notedown( MIDI_DRUM->sequencer, MIDI_DRUM->channel, 48+key+12*MIDI_DRUM->octave, MIDI_DRUM->velocity);}
-   }
-        else{
-		      //printf("noteup\n");
+    }
+        if (!(MIDI_DRUM->key_state&(1<<(24-key)))) {
+		      printf("noteup %d\n",key);
             MIDI_DRUM->noteup(MIDI_DRUM->sequencer, MIDI_DRUM->channel, 48+key+12*MIDI_DRUM->octave, 0);}}
 
 //callback for rockband3 keyboard

--- a/src/rb3keyboard.c
+++ b/src/rb3keyboard.c
@@ -1,186 +1,221 @@
-//janifr
-//based on rbkit.c by ssj71
-//rbkit.c
+// janifr, jasperro
+// based on rbkit.c by ssj71
+// rbkit.c
 #include "rb3keyboard.h"
 //#include "constants.h"
 
-void init_rb3_keyboard(MIDIDRUM* MIDI_DRUM)
-{
-    MIDI_DRUM->key_state=0;
-    MIDI_DRUM->prev_keystate=0;
-    MIDI_DRUM->velocity=0;
-    MIDI_DRUM->channel=0;
+void init_rb3_keyboard(MIDIDRUM *MIDI_DRUM) {
+  switch (MIDI_DRUM->kit) {
+  case WII_RB3_KEYBOARD:
+    MIDI_DRUM->buf_indx[ONE] = 0;
+    MIDI_DRUM->buf_mask[ONE] = 0x04;
+    MIDI_DRUM->buf_indx[B_BUTTON] = 0;
+    MIDI_DRUM->buf_mask[B_BUTTON] = 0x04;
 
-	MIDI_DRUM->buf_indx[ONE] = 0;
-	MIDI_DRUM->buf_mask[ONE] = 0x04;
-	MIDI_DRUM->buf_indx[B_BUTTON] = 0;
-	MIDI_DRUM->buf_mask[B_BUTTON] = 0x04;
+    MIDI_DRUM->buf_indx[UP] = 2;
+    MIDI_DRUM->buf_mask[UP] = 0x08;
+    MIDI_DRUM->buf_indx[DOWN] = 2;
+    MIDI_DRUM->buf_mask[DOWN] = 0x04;
+    MIDI_DRUM->buf_indx[LEFT] = 2;
+    MIDI_DRUM->buf_mask[LEFT] = 0x01;
+    MIDI_DRUM->buf_indx[RIGHT] = 2;
+    MIDI_DRUM->buf_mask[RIGHT] = 0x02;
 
-	MIDI_DRUM->buf_indx[UP] = 14;
-	MIDI_DRUM->buf_mask[UP] = 0x01;
-	MIDI_DRUM->buf_indx[DOWN] = 14;
-	MIDI_DRUM->buf_mask[DOWN] = 0x02;
-	MIDI_DRUM->buf_indx[LEFT] = 14;
-	MIDI_DRUM->buf_mask[LEFT] = 0x04;
-	MIDI_DRUM->buf_indx[RIGHT] = 14;
-	MIDI_DRUM->buf_mask[RIGHT] = 0x08;
+    MIDI_DRUM->buf_indx[MINUS] = 1;
+    MIDI_DRUM->buf_mask[MINUS] = 0x01;
+    MIDI_DRUM->buf_indx[PLUS] = 1;
+    MIDI_DRUM->buf_mask[PLUS] = 0x02;
 
-	MIDI_DRUM->buf_indx[MINUS] = 15;
-	MIDI_DRUM->buf_mask[MINUS] = 0x04;
-	MIDI_DRUM->buf_indx[PLUS] = 15;
-	MIDI_DRUM->buf_mask[PLUS] = 0x02;
+    MIDI_DRUM->buf_indx[A_BUTTON] = 0;
+    MIDI_DRUM->buf_mask[A_BUTTON] = 0x02;
+    MIDI_DRUM->buf_indx[B_BUTTON] = 0;
+    MIDI_DRUM->buf_mask[B_BUTTON] = 0x04;
+    MIDI_DRUM->buf_indx[ONE] = 0;
+    MIDI_DRUM->buf_mask[ONE] = 0x01;
+    MIDI_DRUM->buf_indx[TWO] = 0;
+    MIDI_DRUM->buf_mask[TWO] = 0x08;
 
-	MIDI_DRUM->buf_indx[A_BUTTON] = 0;
-	MIDI_DRUM->buf_mask[A_BUTTON] = 0x02;
-	MIDI_DRUM->buf_indx[B_BUTTON] = 0;
-	MIDI_DRUM->buf_mask[B_BUTTON] = 0x04;
-	MIDI_DRUM->buf_indx[ONE] = 0;
-	MIDI_DRUM->buf_mask[ONE] = 0x01;
-	MIDI_DRUM->buf_indx[TWO] = 0;
-	MIDI_DRUM->buf_mask[TWO] = 0x08;
+    MIDI_DRUM->buf_indx[CONNECT] = 1;
+    MIDI_DRUM->buf_mask[CONNECT] = 0x10;
 
-	MIDI_DRUM->buf_indx[CONNECT] = 1;
-	MIDI_DRUM->buf_mask[CONNECT] = 0x10;
+    MIDI_DRUM->buf_indx[KEYS0] = 5;
+    MIDI_DRUM->buf_indx[KEYS1] = 6;
+    MIDI_DRUM->buf_indx[KEYS2] = 7;
+    MIDI_DRUM->buf_indx[KEYS3] = 8;
 
-	MIDI_DRUM->buf_indx[KEYS0] = 8;
-	MIDI_DRUM->buf_indx[KEYS1] = 9;
-	MIDI_DRUM->buf_indx[KEYS2] = 10;
-	MIDI_DRUM->buf_indx[KEYS3] = 11;
+    MIDI_DRUM->buf_indx[EXPRESSION] = 15;
+    MIDI_DRUM->buf_mask[EXPRESSION] = 0x7f;
+    MIDI_DRUM->buf_indx[EXPR_TOGGLE] = 13;
+    MIDI_DRUM->buf_mask[EXPR_TOGGLE] = 0x80;
+    break;
+  case XB_RB3_KEYBOARD:
+    MIDI_DRUM->buf_indx[UP] = 7;
+    MIDI_DRUM->buf_mask[UP] = 0x01;
+    MIDI_DRUM->buf_indx[DOWN] = 7;
+    MIDI_DRUM->buf_mask[DOWN] = 0x02;
+    MIDI_DRUM->buf_indx[LEFT] = 7;
+    MIDI_DRUM->buf_mask[LEFT] = 0x04;
+    MIDI_DRUM->buf_indx[RIGHT] = 7;
+    MIDI_DRUM->buf_mask[RIGHT] = 0x08;
 
-	MIDI_DRUM->buf_indx[EXPRESSION] = 15;
-	MIDI_DRUM->buf_mask[EXPRESSION] = 0x7f;
-	MIDI_DRUM->buf_indx[EXPR_TOGGLE] = 13;
-	MIDI_DRUM->buf_mask[EXPR_TOGGLE] = 0x80;
+    MIDI_DRUM->buf_indx[MINUS] = 8;
+    MIDI_DRUM->buf_mask[MINUS] = 0x04;
+    MIDI_DRUM->buf_indx[PLUS] = 8;
+    MIDI_DRUM->buf_mask[PLUS] = 0x08;
 
-	MIDI_DRUM->buf_indx[NOTHING] = 17;
-	MIDI_DRUM->buf_mask[NOTHING] = 0x7f;
+    MIDI_DRUM->buf_indx[A_BUTTON] = 8;
+    MIDI_DRUM->buf_mask[A_BUTTON] = 0x01;
+    MIDI_DRUM->buf_indx[B_BUTTON] = 8;
+    MIDI_DRUM->buf_mask[B_BUTTON] = 0x02;
+    MIDI_DRUM->buf_indx[ONE] = 0;
+    MIDI_DRUM->buf_mask[ONE] = 0x01;
+    MIDI_DRUM->buf_indx[TWO] = 0;
+    MIDI_DRUM->buf_mask[TWO] = 0x08;
 
+    MIDI_DRUM->buf_indx[CONNECT] = 1;
+    MIDI_DRUM->buf_mask[CONNECT] = 0x10;
+
+    MIDI_DRUM->buf_indx[KEYS0] = 8;
+    MIDI_DRUM->buf_indx[KEYS1] = 9;
+    MIDI_DRUM->buf_indx[KEYS2] = 10;
+    MIDI_DRUM->buf_indx[KEYS3] = 11;
+
+    MIDI_DRUM->buf_indx[EXPRESSION] = 15;
+    MIDI_DRUM->buf_mask[EXPRESSION] = 0x7f;
+    MIDI_DRUM->buf_indx[EXPR_TOGGLE] = 13;
+    MIDI_DRUM->buf_mask[EXPR_TOGGLE] = 0x80;
+
+    MIDI_DRUM->buf_indx[NOTHING] = 17;
+    MIDI_DRUM->buf_mask[NOTHING] = 0x7f;
+    break;
+  }
+  MIDI_DRUM->key_state = 0;
+  MIDI_DRUM->prev_keystate = 0;
+  MIDI_DRUM->velocity = 0;
+  MIDI_DRUM->channel = 0;
 }
 
-static inline void get_velocity(MIDIDRUM* MIDI_DRUM)
-{
-    //Velocity data is transmitted for up to 5 keys pressed same time.
-    //This is the reason for the weird velocity reading algorithm.
-    //For this reason the 6th key wont get any reasonable velocity data.
-    if (MIDI_DRUM->buf[12]!=0)
-    MIDI_DRUM->velocity=MIDI_DRUM->buf[12];
-    else if (MIDI_DRUM->buf[11]!=0)
-    MIDI_DRUM->velocity=MIDI_DRUM->buf[11];
-    else if (MIDI_DRUM->buf[10]!=0)
-        MIDI_DRUM->velocity=MIDI_DRUM->buf[10];
-    else if (MIDI_DRUM->buf[9]!=0)
-        MIDI_DRUM->velocity=MIDI_DRUM->buf[9];
-    else 
-    MIDI_DRUM->velocity=MIDI_DRUM->buf[8]&0x7f;
-
-	 //MIDI_DRUM->velocity=255;
+static inline void get_velocity(MIDIDRUM *MIDI_DRUM) {
+  // Velocity data is transmitted for up to 5 keys pressed same time.
+  // This is the reason for the weird velocity reading algorithm.
+  // For this reason the 6th key wont get any reasonable velocity data.
+  if (MIDI_DRUM->buf[12] != 0)
+    MIDI_DRUM->velocity = MIDI_DRUM->buf[12];
+  else if (MIDI_DRUM->buf[11] != 0)
+    MIDI_DRUM->velocity = MIDI_DRUM->buf[11];
+  else if (MIDI_DRUM->buf[10] != 0)
+    MIDI_DRUM->velocity = MIDI_DRUM->buf[10];
+  else if (MIDI_DRUM->buf[9] != 0)
+    MIDI_DRUM->velocity = MIDI_DRUM->buf[9];
+  else
+    MIDI_DRUM->velocity = MIDI_DRUM->buf[8] & 0x7f;
 }
 
-static inline void handle_key(MIDIDRUM* MIDI_DRUM, unsigned char key)
-{
-    //printf("%d\n",1<<(24-key));
-    if ((MIDI_DRUM->key_state&(1<<(24-key))) != 
-    (MIDI_DRUM->prev_keystate&(1<<(24-key))))
-    {
-        get_velocity(MIDI_DRUM);
-        printf("key %d\n",key);
-        if (MIDI_DRUM->key_state&(1<<(24-key))){
-            MIDI_DRUM->notedown( MIDI_DRUM->sequencer, MIDI_DRUM->channel, 48+key+12*MIDI_DRUM->octave, MIDI_DRUM->velocity);}
+static inline void handle_key(MIDIDRUM *MIDI_DRUM, unsigned char key) {
+  // printf("%d\n",1<<(24-key));
+  if ((MIDI_DRUM->key_state & (1 << (24 - key))) !=
+      (MIDI_DRUM->prev_keystate & (1 << (24 - key)))) {
+    get_velocity(MIDI_DRUM);
+    printf("key %d\n", key);
+    if (MIDI_DRUM->key_state & (1 << (24 - key))) {
+      MIDI_DRUM->notedown(MIDI_DRUM->sequencer, MIDI_DRUM->channel,
+                          48 + key + 12 * MIDI_DRUM->octave,
+                          MIDI_DRUM->velocity);
     }
-        if (!(MIDI_DRUM->key_state&(1<<(24-key)))) {
-		      printf("noteup %d\n",key);
-            MIDI_DRUM->noteup(MIDI_DRUM->sequencer, MIDI_DRUM->channel, 48+key+12*MIDI_DRUM->octave, 0);}}
-
-//callback for rockband3 keyboard
-void cb_irq_rb3_keyboard(struct libusb_transfer *transfer)
-{
-    MIDIDRUM* MIDI_DRUM = (MIDIDRUM*)transfer->user_data; 
-    if (transfer->status != LIBUSB_TRANSFER_COMPLETED) {
-        fprintf(stderr, "irq transfer status %d? %d\n", transfer->status, LIBUSB_TRANSFER_ERROR);
-        do_exit = 2;
-        libusb_free_transfer(transfer);
-        transfer = NULL;
-        return;
-    }
-
-    //the keys are the most critical for latency, ctl values can be slower
-    MIDI_DRUM->key_state=
-      (MIDI_DRUM->buf[MIDI_DRUM->buf_indx[KEYS0]]<<17)+(MIDI_DRUM->buf[MIDI_DRUM->buf_indx[KEYS1]]<<9)+
-      (MIDI_DRUM->buf[MIDI_DRUM->buf_indx[KEYS2]]<<1)+((MIDI_DRUM->buf[MIDI_DRUM->buf_indx[KEYS3]])>>7);
-get_state(MIDI_DRUM,NOTHING);
-if (MIDI_DRUM->drum_state[NOTHING]){
-        handle_key(MIDI_DRUM,0);
-        handle_key(MIDI_DRUM,1);
-        handle_key(MIDI_DRUM,2);
-        handle_key(MIDI_DRUM,3);
-        handle_key(MIDI_DRUM,4);
-        handle_key(MIDI_DRUM,5);
-        handle_key(MIDI_DRUM,6);
-        handle_key(MIDI_DRUM,7);
-        handle_key(MIDI_DRUM,8);
-        handle_key(MIDI_DRUM,9);
-        handle_key(MIDI_DRUM,10);
-        handle_key(MIDI_DRUM,11);
-        handle_key(MIDI_DRUM,12);
-        handle_key(MIDI_DRUM,13);
-        handle_key(MIDI_DRUM,14);
-        handle_key(MIDI_DRUM,15);
-        handle_key(MIDI_DRUM,16);
-        handle_key(MIDI_DRUM,17);
-        handle_key(MIDI_DRUM,18);
-        handle_key(MIDI_DRUM,19);
-        handle_key(MIDI_DRUM,20);
-        handle_key(MIDI_DRUM,21);
-        handle_key(MIDI_DRUM,22);
-        handle_key(MIDI_DRUM,23);
-        handle_key(MIDI_DRUM,24);
+  }
+  if (!(MIDI_DRUM->key_state & (1 << (24 - key)))) {
+    MIDI_DRUM->noteup(MIDI_DRUM->sequencer, MIDI_DRUM->channel,
+                      48 + key + 12 * MIDI_DRUM->octave, 0);
+  }
 }
 
-    //these buttons control octave
-    //octave can get up to +-4 octaves
-    get_state(MIDI_DRUM,PLUS);
-    get_state(MIDI_DRUM,MINUS);
-    get_state(MIDI_DRUM,CONNECT);
-    
-    //TODO: this leaves opportunity for currently-on notes to be "orphaned" 
-    //so that the note-off comes for a different octave
-    //NOTE: Also the + and - buttons correspond to start and select on other
-    //platforms, when using the midi out port the 1 and B buttons change octave
-    //for now, I don't mind just doing it this way
-    if(MIDI_DRUM->drum_state[MINUS] && ! MIDI_DRUM->prev_state[MINUS]
-        && MIDI_DRUM->octave>-4)
-        MIDI_DRUM->octave--;
-    if(MIDI_DRUM->drum_state[PLUS] && ! MIDI_DRUM->prev_state[PLUS]
-        && MIDI_DRUM->octave<4)
-        MIDI_DRUM->octave++;
-    if(MIDI_DRUM->drum_state[CONNECT] && ! MIDI_DRUM->prev_state[CONNECT])
-        MIDI_DRUM->octave = 0;
+// callback for rockband3 keyboard
+void cb_irq_rb3_keyboard(struct libusb_transfer *transfer) {
+  MIDIDRUM *MIDI_DRUM = (MIDIDRUM *)transfer->user_data;
+  if (transfer->status != LIBUSB_TRANSFER_COMPLETED) {
+    fprintf(stderr, "irq transfer status %d? %d\n", transfer->status,
+            LIBUSB_TRANSFER_ERROR);
+    do_exit = 2;
+    libusb_free_transfer(transfer);
+    transfer = NULL;
+    return;
+  }
 
-    //now the pitchbender
-    get_state(MIDI_DRUM,EXPR_TOGGLE);
-    get_state(MIDI_DRUM,EXPRESSION);
-    if(MIDI_DRUM->drum_state[EXPRESSION] != MIDI_DRUM->prev_state[EXPRESSION])
-    {
-        if(MIDI_DRUM->drum_state[EXPR_TOGGLE])
-        {
-            //should be MOD wheel change
-        }
-        else
-        {
-            //TODO: figure out how this data is formatted.
-            MIDI_DRUM->pitchbend(MIDI_DRUM->sequencer,MIDI_DRUM->channel,MIDI_DRUM->drum_state[EXPRESSION]); 
-        }
+  // the keys are the most critical for latency, ctl values can be slower
+  MIDI_DRUM->key_state = (MIDI_DRUM->buf[MIDI_DRUM->buf_indx[KEYS0]] << 17) +
+                         (MIDI_DRUM->buf[MIDI_DRUM->buf_indx[KEYS1]] << 9) +
+                         (MIDI_DRUM->buf[MIDI_DRUM->buf_indx[KEYS2]] << 1) +
+                         ((MIDI_DRUM->buf[MIDI_DRUM->buf_indx[KEYS3]]) >> 7);
+  get_state(MIDI_DRUM, NOTHING);
+  if (MIDI_DRUM->drum_state[NOTHING]) {
+    handle_key(MIDI_DRUM, 0);
+    handle_key(MIDI_DRUM, 1);
+    handle_key(MIDI_DRUM, 2);
+    handle_key(MIDI_DRUM, 3);
+    handle_key(MIDI_DRUM, 4);
+    handle_key(MIDI_DRUM, 5);
+    handle_key(MIDI_DRUM, 6);
+    handle_key(MIDI_DRUM, 7);
+    handle_key(MIDI_DRUM, 8);
+    handle_key(MIDI_DRUM, 9);
+    handle_key(MIDI_DRUM, 10);
+    handle_key(MIDI_DRUM, 11);
+    handle_key(MIDI_DRUM, 12);
+    handle_key(MIDI_DRUM, 13);
+    handle_key(MIDI_DRUM, 14);
+    handle_key(MIDI_DRUM, 15);
+    handle_key(MIDI_DRUM, 16);
+    handle_key(MIDI_DRUM, 17);
+    handle_key(MIDI_DRUM, 18);
+    handle_key(MIDI_DRUM, 19);
+    handle_key(MIDI_DRUM, 20);
+    handle_key(MIDI_DRUM, 21);
+    handle_key(MIDI_DRUM, 22);
+    handle_key(MIDI_DRUM, 23);
+    handle_key(MIDI_DRUM, 24);
+  }
+
+  // these buttons control octave
+  // octave can get up to +-4 octaves
+  get_state(MIDI_DRUM, PLUS);
+  get_state(MIDI_DRUM, MINUS);
+  get_state(MIDI_DRUM, CONNECT);
+
+  // TODO: this leaves opportunity for currently-on notes to be "orphaned"
+  // so that the note-off comes for a different octave
+  // NOTE: Also the + and - buttons correspond to start and select on other
+  // platforms, when using the midi out port the 1 and B buttons change octave
+  // for now, I don't mind just doing it this way
+  if (MIDI_DRUM->drum_state[MINUS] && !MIDI_DRUM->prev_state[MINUS] &&
+      MIDI_DRUM->octave > -4)
+    MIDI_DRUM->octave--;
+  if (MIDI_DRUM->drum_state[PLUS] && !MIDI_DRUM->prev_state[PLUS] &&
+      MIDI_DRUM->octave < 4)
+    MIDI_DRUM->octave++;
+  if (MIDI_DRUM->drum_state[CONNECT] && !MIDI_DRUM->prev_state[CONNECT])
+    MIDI_DRUM->octave = 0;
+
+  // now the pitchbender
+  get_state(MIDI_DRUM, EXPR_TOGGLE);
+  get_state(MIDI_DRUM, EXPRESSION);
+  if (MIDI_DRUM->drum_state[EXPRESSION] != MIDI_DRUM->prev_state[EXPRESSION]) {
+    if (MIDI_DRUM->drum_state[EXPR_TOGGLE]) {
+      // should be MOD wheel change
+    } else {
+      // TODO: figure out how this data is formatted.
+      MIDI_DRUM->pitchbend(MIDI_DRUM->sequencer, MIDI_DRUM->channel,
+                           MIDI_DRUM->drum_state[EXPRESSION]);
     }
+  }
 
-    memcpy(MIDI_DRUM->prev_state,MIDI_DRUM->drum_state,NUM_DRUMS);
+  memcpy(MIDI_DRUM->prev_state, MIDI_DRUM->drum_state, NUM_DRUMS);
 
-    if (MIDI_DRUM->verbose)
-    {
-        print_keys(MIDI_DRUM);
-        print_buf(MIDI_DRUM);
-    }
-    MIDI_DRUM->prev_keystate=MIDI_DRUM->key_state; 
-    
-    if (libusb_submit_transfer(transfer) < 0)
-        do_exit = 2;
+  if (MIDI_DRUM->verbose) {
+    print_keys(MIDI_DRUM);
+    print_buf(MIDI_DRUM);
+  }
+  MIDI_DRUM->prev_keystate = MIDI_DRUM->key_state;
+
+  if (libusb_submit_transfer(transfer) < 0)
+    do_exit = 2;
 }

--- a/src/rb3keyboard.c
+++ b/src/rb3keyboard.c
@@ -16,18 +16,18 @@ void init_rb3_keyboard(MIDIDRUM* MIDI_DRUM)
 	MIDI_DRUM->buf_indx[B_BUTTON] = 0;
 	MIDI_DRUM->buf_mask[B_BUTTON] = 0x04;
 
-	MIDI_DRUM->buf_indx[UP] = 2;
-	MIDI_DRUM->buf_mask[UP] = 0x08;
-	MIDI_DRUM->buf_indx[DOWN] = 2;
-	MIDI_DRUM->buf_mask[DOWN] = 0x04;
-	MIDI_DRUM->buf_indx[LEFT] = 2;
-	MIDI_DRUM->buf_mask[LEFT] = 0x01;
-	MIDI_DRUM->buf_indx[RIGHT] = 2;
-	MIDI_DRUM->buf_mask[RIGHT] = 0x02;
+	MIDI_DRUM->buf_indx[UP] = 14;
+	MIDI_DRUM->buf_mask[UP] = 0x01;
+	MIDI_DRUM->buf_indx[DOWN] = 14;
+	MIDI_DRUM->buf_mask[DOWN] = 0x02;
+	MIDI_DRUM->buf_indx[LEFT] = 14;
+	MIDI_DRUM->buf_mask[LEFT] = 0x04;
+	MIDI_DRUM->buf_indx[RIGHT] = 14;
+	MIDI_DRUM->buf_mask[RIGHT] = 0x08;
 
-	MIDI_DRUM->buf_indx[MINUS] = 1;
-	MIDI_DRUM->buf_mask[MINUS] = 0x01;
-	MIDI_DRUM->buf_indx[PLUS] = 1;
+	MIDI_DRUM->buf_indx[MINUS] = 15;
+	MIDI_DRUM->buf_mask[MINUS] = 0x04;
+	MIDI_DRUM->buf_indx[PLUS] = 15;
 	MIDI_DRUM->buf_mask[PLUS] = 0x02;
 
 	MIDI_DRUM->buf_indx[A_BUTTON] = 0;
@@ -42,15 +42,19 @@ void init_rb3_keyboard(MIDIDRUM* MIDI_DRUM)
 	MIDI_DRUM->buf_indx[CONNECT] = 1;
 	MIDI_DRUM->buf_mask[CONNECT] = 0x10;
 
-	MIDI_DRUM->buf_indx[KEYS0] = 5;
-	MIDI_DRUM->buf_indx[KEYS1] = 6;
-	MIDI_DRUM->buf_indx[KEYS2] = 7;
-	MIDI_DRUM->buf_indx[KEYS3] = 8;
+	MIDI_DRUM->buf_indx[KEYS0] = 8;
+	MIDI_DRUM->buf_indx[KEYS1] = 9;
+	MIDI_DRUM->buf_indx[KEYS2] = 10;
+	MIDI_DRUM->buf_indx[KEYS3] = 11;
 
 	MIDI_DRUM->buf_indx[EXPRESSION] = 15;
 	MIDI_DRUM->buf_mask[EXPRESSION] = 0x7f;
 	MIDI_DRUM->buf_indx[EXPR_TOGGLE] = 13;
 	MIDI_DRUM->buf_mask[EXPR_TOGGLE] = 0x80;
+
+	MIDI_DRUM->buf_indx[NOTHING] = 17;
+	MIDI_DRUM->buf_mask[NOTHING] = 0x7f;
+
 }
 
 static inline void get_velocity(MIDIDRUM* MIDI_DRUM)
@@ -68,6 +72,8 @@ static inline void get_velocity(MIDIDRUM* MIDI_DRUM)
         MIDI_DRUM->velocity=MIDI_DRUM->buf[9];
     else 
     MIDI_DRUM->velocity=MIDI_DRUM->buf[8]&0x7f;
+
+	 //MIDI_DRUM->velocity=255;
 }
 
 static inline void handle_key(MIDIDRUM* MIDI_DRUM, unsigned char key)
@@ -77,13 +83,13 @@ static inline void handle_key(MIDIDRUM* MIDI_DRUM, unsigned char key)
     (MIDI_DRUM->prev_keystate&(1<<(24-key))))
     {
         get_velocity(MIDI_DRUM);
-        printf("key %d\n",key);
-        if (MIDI_DRUM->key_state&(1<<(24-key)))
-            MIDI_DRUM->notedown( MIDI_DRUM->sequencer, MIDI_DRUM->channel, 48+key+12*MIDI_DRUM->octave, MIDI_DRUM->velocity);
-        else
-            MIDI_DRUM->noteup(MIDI_DRUM->sequencer, MIDI_DRUM->channel, 48+key+12*MIDI_DRUM->octave, 0);
+        //printf("key %d\n",key);
+        if (MIDI_DRUM->key_state&(1<<(24-key))){
+            MIDI_DRUM->notedown( MIDI_DRUM->sequencer, MIDI_DRUM->channel, 48+key+12*MIDI_DRUM->octave, MIDI_DRUM->velocity);}
    }
-}
+        else{
+		      //printf("noteup\n");
+            MIDI_DRUM->noteup(MIDI_DRUM->sequencer, MIDI_DRUM->channel, 48+key+12*MIDI_DRUM->octave, 0);}}
 
 //callback for rockband3 keyboard
 void cb_irq_rb3_keyboard(struct libusb_transfer *transfer)
@@ -101,9 +107,8 @@ void cb_irq_rb3_keyboard(struct libusb_transfer *transfer)
     MIDI_DRUM->key_state=
       (MIDI_DRUM->buf[MIDI_DRUM->buf_indx[KEYS0]]<<17)+(MIDI_DRUM->buf[MIDI_DRUM->buf_indx[KEYS1]]<<9)+
       (MIDI_DRUM->buf[MIDI_DRUM->buf_indx[KEYS2]]<<1)+((MIDI_DRUM->buf[MIDI_DRUM->buf_indx[KEYS3]])>>7);
-
-    if (MIDI_DRUM->key_state != MIDI_DRUM->prev_keystate)
-    {
+get_state(MIDI_DRUM,NOTHING);
+if (MIDI_DRUM->drum_state[NOTHING]){
         handle_key(MIDI_DRUM,0);
         handle_key(MIDI_DRUM,1);
         handle_key(MIDI_DRUM,2);
@@ -129,7 +134,7 @@ void cb_irq_rb3_keyboard(struct libusb_transfer *transfer)
         handle_key(MIDI_DRUM,22);
         handle_key(MIDI_DRUM,23);
         handle_key(MIDI_DRUM,24);
-    }
+}
 
     //these buttons control octave
     //octave can get up to +-4 octaves


### PR DESCRIPTION
I added xbox360 rockband3 wireless keyboard support to the software with command line option `-xbkey`. It could be that I broke WII wireless keyboard support, but I can't check because I don't own the hardware. Everything works except the whammy bar. The X and Y buttons increase and decrease the octave respectively.