### PR TITLE
Add support for PS3 Keyboard

### DIFF
--- a/src/mididrum.h
+++ b/src/mididrum.h
@@ -120,7 +120,8 @@ typedef enum {
     GUITARS,
 
     WII_RB3_KEYBOARD,
-    XB_RB3_KEYBOARD
+    XB_RB3_KEYBOARD,
+    PS3_RB3_KEYBOARD
 }kit_types;
 
 //primary object for the system

--- a/src/rb3keyboard.c
+++ b/src/rb3keyboard.c
@@ -88,6 +88,30 @@ void init_rb3_keyboard(MIDIDRUM *MIDI_DRUM) {
         MIDI_DRUM->buf_indx[NOTHING] = 17;
         MIDI_DRUM->buf_mask[NOTHING] = 0x7f;
         break;
+
+    case PS3_RB3_KEYBOARD:
+        MIDI_DRUM->buf_indx[MINUS] = 1;
+        MIDI_DRUM->buf_mask[MINUS] = 0x01;
+        MIDI_DRUM->buf_indx[PLUS] = 1;
+        MIDI_DRUM->buf_mask[PLUS] = 0x02;
+
+        MIDI_DRUM->buf_indx[CONNECT] = 1;
+        MIDI_DRUM->buf_mask[CONNECT] = 0x10;
+
+        MIDI_DRUM->buf_indx[KEYS0] = 5;
+        MIDI_DRUM->buf_indx[KEYS1] = 6;
+        MIDI_DRUM->buf_indx[KEYS2] = 7;
+        MIDI_DRUM->buf_indx[KEYS3] = 8;
+
+        MIDI_DRUM->buf_indx[EXPRESSION] = 15;
+        MIDI_DRUM->buf_mask[EXPRESSION] = 0x7f;
+        MIDI_DRUM->buf_indx[EXPR_TOGGLE] = 13;
+        MIDI_DRUM->buf_mask[EXPR_TOGGLE] = 0x80;
+
+        MIDI_DRUM->buf_indx[NOTHING] = 14;
+        MIDI_DRUM->buf_mask[NOTHING] = 0x7f;
+        break;
+
     }
     MIDI_DRUM->key_state = 0;
     MIDI_DRUM->prev_keystate = 0;
@@ -121,11 +145,11 @@ static inline void handle_key(MIDIDRUM *MIDI_DRUM, unsigned char key) {
             MIDI_DRUM->notedown(MIDI_DRUM->sequencer, MIDI_DRUM->channel,
                                                     48 + key + 12 * MIDI_DRUM->octave,
                                                     MIDI_DRUM->velocity);
+        } else {
+            MIDI_DRUM->noteup(MIDI_DRUM->sequencer, MIDI_DRUM->channel,
+                                                    48 + key + 12 * MIDI_DRUM->octave,
+                                                    0);
         }
-    }
-    if (!(MIDI_DRUM->key_state & (1 << (24 - key)))) {
-        MIDI_DRUM->noteup(MIDI_DRUM->sequencer, MIDI_DRUM->channel,
-                                            48 + key + 12 * MIDI_DRUM->octave, 0);
     }
 }
 


### PR DESCRIPTION
Init code taken from what RPCS3 sends to the keyboard when launching rb3. Without sending, the keyboard doesn't return any (keyboard) keys.

Handle key changed so previous state is used for noteup and notedown. Was getting noteup for every key not pressed everytime in aseqdump.